### PR TITLE
Change Test::Most dep to Test::More to avoid unnecessary test modules

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -7,7 +7,7 @@ my $builder = Module::Build->new(
     license           => 'perl',
     dist_author       => 'Curtis "Ovid" Poe <ovid@cpan.org>',
     dist_version_from => 'lib/MooseX/Role/Strict.pm',
-    build_requires    => { 'Test::Most' => 0.21, },
+    build_requires    => { 'Test::More' => 0.96, },
     requires          => {
         'Moose' => 0.89,    # for --metaclass, -excludes
     },

--- a/META.yml
+++ b/META.yml
@@ -3,7 +3,7 @@ abstract: "use strict 'roles'"
 author:
   - "Curtis \"Ovid\" Poe <ovid@cpan.org>"
 build_requires:
-  Test::Most: 0.21
+  Test::More: 0.96
 configure_requires:
   Module::Build: 0.36
 generated_by: 'Module::Build version 0.3607'

--- a/t/override.t
+++ b/t/override.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::Most tests => 4;
+use Test::More tests => 4;
 use lib 'lib';
 
 {


### PR DESCRIPTION
I've nothing against Test::Most, but not everything it pulls in is necessary to run the MooseX::Role::Strict tests. (Not as far as I can tell, at least.)
