### PR TITLE
Fix incorrect code to synopsis.

### DIFF
--- a/lib/MooseX/Role/Strict.pm
+++ b/lib/MooseX/Role/Strict.pm
@@ -125,7 +125,7 @@ To resolve this, explictly exclude the 'conflict' method:
     {
         package My::Class;
         use Moose;
-        with 'My::Role' => { -excludes => 'conflict' };
+        with 'My::Role' => { -excludes => [ 'conflict' ] };
         sub conflict {}
     }
 


### PR DESCRIPTION
To run code

``` perl
use strict;
use warnings;

{
    package My::Role;
    use MooseX::Role::Strict;
    sub conflict {}
}
{
    package My::Class;
    use Moose;
    with 'My::Role' => { -excludes => 'conflict' } ;
    sub conflict {}
}
```

Error:
Can't use string ("conflict") as an ARRAY ref while "strict refs" in use at
/usr/lib/perl5/Moose/Meta/Role/Application.pm line 34.

Valid:

``` perl
use strict;
use warnings;

{
    package My::Role;
    use MooseX::Role::Strict;
    sub conflict {}
}
{
    package My::Class;
    use Moose;
    with 'My::Role' => { -excludes => [ 'conflict' ] } ;
    sub conflict {}
}
```
